### PR TITLE
Added missing `id` attribute to Discovery Map container

### DIFF
--- a/Aufgabe1/gta_v1/public/index.html
+++ b/Aufgabe1/gta_v1/public/index.html
@@ -54,7 +54,7 @@
                     </ul>
                 </div>
 
-                <div class="discovery__map">
+                <div id="map" class="discovery__map">
                     <img src="./images/mapview.jpg" alt="a map with locations" id="mapView" />
                     <span>Result map</span>
                 </div>


### PR DESCRIPTION
# Changes
Added missing `id` attribute to discovery map container, which is required for [Task 2](https://github.com/zirpins/vs1lab/tree/master/Aufgabe2#213-css-aus-aufgabe-1-erweitern). Since Task 2 builds on Task 1 and involves copying the `index.html` from Task 1, I made this change directly in Task 1. This ensures that the required modifications are carried over smoothly when progressing to Task 2.