### PR TITLE
Fix incorrect tag location property usage in `updateMarkers` method

### DIFF
--- a/Aufgabe2/gta_v2/public/javascripts/geotagging.js
+++ b/Aufgabe2/gta_v2/public/javascripts/geotagging.js
@@ -104,7 +104,7 @@ class MapManager {
             .bindPopup("Your Location")
             .addTo(this.#markers);
         for (const tag of tags) {
-            L.marker([tag.location.latitude,tag.location.longitude])
+            L.marker([tag.latitude,tag.longitude])
                 .bindPopup(tag.name)
                 .addTo(this.#markers);  
         }

--- a/Aufgabe3/gta_v3/public/javascripts/map-manager.js
+++ b/Aufgabe3/gta_v3/public/javascripts/map-manager.js
@@ -52,7 +52,7 @@
             .bindPopup("Your Location")
             .addTo(this.#markers);
         for (const tag of tags) {
-            L.marker([tag.location.latitude,tag.location.longitude], { icon: this.#defaultIcon })
+            L.marker([tag.latitude,tag.longitude], { icon: this.#defaultIcon })
                 .bindPopup(tag.name)
                 .addTo(this.#markers);  
         }


### PR DESCRIPTION
# Changes

- Fixed the incorrect usage of `tag.location.latitude` and `tag.location.longitude` in the `updateMarkers` method by replacing them with the correct `tag.latitude` and `tag.longitude` properties. The method’s description specifies `@param {{latitude, longitude, name}[]} tags ...`, which indicates that `tags` do not contain a `location` object.
- These changes are especially important starting from Task 3, where `tags` will actually be passed to the method. In Task 2, however, the `updateMarkers` method is only called with `latitude` and `longitude`, and the `tags` array is empty, so no error occurred in that context.
- Despite this, I applied the fix to Task 2 as well for the sake of consistency, even though it wasn’t strictly necessary.